### PR TITLE
chore/codeql fixes

### DIFF
--- a/src/patterns/prototype-pollution.js
+++ b/src/patterns/prototype-pollution.js
@@ -8,6 +8,8 @@
  * OWASP guidelines, and common attack vectors in JavaScript applications.
  */
 
+const { safeBatchTest } = require('../utils/redos-safe-patterns');
+
 const SEVERITY_LEVELS = {
   CRITICAL: 'critical',
   HIGH: 'high',
@@ -285,11 +287,11 @@ function checkObjectKeys (obj, prefix = '', visited = new WeakSet()) {
 function checkPollutionPatterns (input) {
   const detected = [];
 
-  for (const pattern of POLLUTION_PATTERNS) {
-    if (pattern.test(input)) {
-      detected.push(`pollution_pattern:${pattern.source}`);
-    }
-  }
+  // Use safeBatchTest to prevent ReDoS attacks
+  const results = safeBatchTest(POLLUTION_PATTERNS, input, 100);
+  results.matched.forEach(pattern => {
+    detected.push(`pollution_pattern:${pattern.source}`);
+  });
 
   return {
     detected: detected.length > 0,
@@ -380,11 +382,11 @@ function checkEncodingBypassPatterns (input) {
 function checkPropertyAccessPatterns (input) {
   const detected = [];
 
-  for (const pattern of PROPERTY_ACCESS_PATTERNS) {
-    if (pattern.test(input)) {
-      detected.push(`property_access:${pattern.source}`);
-    }
-  }
+  // Use safeBatchTest to prevent ReDoS attacks
+  const results = safeBatchTest(PROPERTY_ACCESS_PATTERNS, input, 100);
+  results.matched.forEach(pattern => {
+    detected.push(`property_access:${pattern.source}`);
+  });
 
   return {
     detected: detected.length > 0,

--- a/src/patterns/sql-injection.js
+++ b/src/patterns/sql-injection.js
@@ -8,6 +8,8 @@
  * common SQL injection vectors, and database-specific attack patterns.
  */
 
+const { safeBatchTest } = require('../utils/redos-safe-patterns');
+
 const SEVERITY_LEVELS = {
   CRITICAL: 'critical',
   HIGH: 'high',
@@ -251,11 +253,11 @@ function checkSQLKeywords (input) {
 function checkInjectionPatterns (input) {
   const detected = [];
 
-  for (const pattern of INJECTION_PATTERNS) {
-    if (pattern.test(input)) {
-      detected.push(`injection_pattern:${pattern.source}`);
-    }
-  }
+  // Use safeBatchTest to prevent ReDoS attacks
+  const results = safeBatchTest(INJECTION_PATTERNS, input, 100);
+  results.matched.forEach(pattern => {
+    detected.push(`injection_pattern:${pattern.source}`);
+  });
 
   return {
     detected: detected.length > 0,


### PR DESCRIPTION
- Fixed #44: unified-parser.js:118 - Added ReDoS protection to match() and replace() methods
- Fixed #42: validators/sql.js:646 - Wrapped comment pattern matching with safeBatchTest
- Fixed #39: validators/sql.js:493 - Wrapped SQL injection pattern checking with safeBatchTest
- Fixed #36: validators/command.js:498 - Wrapped shell metacharacter detection with safeBatchTest
- Fixed #29: patterns/sql-injection.js:255 - Wrapped checkInjectionPatterns with safeBatchTest
- Fixed #28: patterns/prototype-pollution.js:384 - Wrapped checkPropertyAccessPatterns with safeBatchTest
- Fixed #25: patterns/prototype-pollution.js:289 - Wrapped checkPollutionPatterns with safeBatchTest
- Fixed #47: examples/test-server.js:63 - Stack trace already conditionally exposed (dev only)
